### PR TITLE
fix: clear 메소드 오동작 수정

### DIFF
--- a/packages/brandpay-sdk/src/loadBrandPay.ts
+++ b/packages/brandpay-sdk/src/loadBrandPay.ts
@@ -1,6 +1,6 @@
 import type { BrandPayConstructor, BrandPayInstance } from '@tosspayments/brandpay__types';
 import { loadScript } from '@tosspayments/sdk-loader';
-import { SCRIPT_URL } from './constants';
+import { SCRIPT_ID, SCRIPT_URL } from './constants';
 
 type BrandPayParams = Parameters<BrandPayConstructor>;
 
@@ -18,7 +18,7 @@ export function loadBrandPay(
   }
 
   // regenerator-runtime 의존성을 없애기 위해 `async` 키워드를 사용하지 않는다
-  return loadScript<BrandPayConstructor>(src, 'BrandPay').then((BrandPay) => {
+  return loadScript<BrandPayConstructor>(src, 'BrandPay', SCRIPT_ID).then((BrandPay) => {
     return BrandPay(clientKey, customerKey, options);
   });
 }

--- a/packages/payment-sdk/src/loadTossPayments.test.ts
+++ b/packages/payment-sdk/src/loadTossPayments.test.ts
@@ -1,4 +1,4 @@
-import { SCRIPT_URL } from './constants';
+import { SCRIPT_ID, SCRIPT_URL } from './constants';
 import { loadTossPayments } from './loadTossPayments';
 
 function dispatchLoadEvent() {
@@ -25,6 +25,7 @@ describe('loadTossPayments', () => {
     const script = document.querySelector(`script[src="${SCRIPT_URL}"]`);
 
     expect(script).not.toBeNull();
+    expect(script?.id).toBe(SCRIPT_ID);
   });
 
   test('2회 이상의 중복 호출 시에도 1회만 inject한다', async () => {
@@ -51,6 +52,7 @@ describe('loadTossPayments', () => {
     await loadPromise;
 
     const script = document.querySelector(`script[src="${testSource}"]`);
+    expect(script?.id).toBe(SCRIPT_ID);
 
     expect(script).not.toBeNull();
   });

--- a/packages/payment-sdk/src/loadTossPayments.ts
+++ b/packages/payment-sdk/src/loadTossPayments.ts
@@ -1,6 +1,6 @@
 import { TossPaymentsInstance, TossPaymentsConstructor } from '@tosspayments/payment__types';
 import { loadScript } from '@tosspayments/sdk-loader';
-import { SCRIPT_URL } from './constants';
+import { SCRIPT_ID, SCRIPT_URL } from './constants';
 
 export function loadTossPayments(
   clientKey: string,
@@ -28,7 +28,7 @@ export function loadTossPayments(
   }
 
   // regenerator-runtime 의존성을 없애기 위해 `async` 키워드를 사용하지 않는다
-  return loadScript<TossPaymentsConstructor>(src, 'TossPayments').then((TossPayments) => {
+  return loadScript<TossPaymentsConstructor>(src, 'TossPayments', SCRIPT_ID).then((TossPayments) => {
     return TossPayments(clientKey);
   });
 }

--- a/packages/payment-widget-sdk/src/loadPaymentWidget.ts
+++ b/packages/payment-widget-sdk/src/loadPaymentWidget.ts
@@ -1,6 +1,6 @@
 import type { PaymentWidgetConstructor, PaymentWidgetInstance } from '@tosspayments/payment-widget__types';
 import { loadScript } from '@tosspayments/sdk-loader';
-import { SCRIPT_URL } from './constants';
+import { SCRIPT_ID, SCRIPT_URL } from './constants';
 
 type PaymentWidgetParams = Parameters<PaymentWidgetConstructor>;
 
@@ -17,7 +17,7 @@ export function loadPaymentWidget(
   }
 
   // regenerator-runtime 의존성을 없애기 위해 `async` 키워드를 사용하지 않는다
-  return loadScript<PaymentWidgetConstructor>(src, 'PaymentWidget').then((PaymentWidget) => {
+  return loadScript<PaymentWidgetConstructor>(src, 'PaymentWidget', SCRIPT_ID).then((PaymentWidget) => {
     return PaymentWidget(clientKey, customerKey);
   });
 }

--- a/packages/sdk-loader/src/index.ts
+++ b/packages/sdk-loader/src/index.ts
@@ -1,6 +1,6 @@
 let cachedPromise: Promise<any> | undefined;
 
-export function loadScript<Namespace>(src: string, namespace: string): Promise<Namespace> {
+export function loadScript<Namespace>(src: string, namespace: string, id?: string): Promise<Namespace> {
   const existingElement = document.querySelector(`[src="${src}"]`);
 
   if (existingElement != null && cachedPromise !== undefined) {
@@ -13,6 +13,9 @@ export function loadScript<Namespace>(src: string, namespace: string): Promise<N
 
   const script = document.createElement('script');
   script.src = src;
+  if (id) {
+    script.id = id;
+  }
 
   cachedPromise = new Promise<Namespace>((resolve, reject) => {
     document.head.appendChild(script);


### PR DESCRIPTION
https://github.com/tosspayments/browser-sdk/pull/9 에서 id 기반 inject가 사라졌으나 clearMethod에서는 ID기반으로 동작하므로 clear~류가 제대로 동작하지 못하는 문제가 있었습니다.

이 문제는 Next.js류의 SPA에서 결제위젯을 사용할시 clear 해주지 않는경우 Bridge에서가 발생하는 원인이 되었습니다.
현재 clear 메소드가 의도대로 동작하지않아 SPA에서 사용시 유의사항이 있습니다.

질문:
- clearMethod도 url 기반으로 변경됨이 옳을까요?
- script_url처럼 id도 옵션으로 받을 수 있어야 할까요?
- 결제위젯의 경우 window.PaymentWidget 뿐만아니라 window.TossPayments 도 생성합니다. `window.TossPayments`도 클리어해주는게 맞는걸까요? 맞다면 현재는 타입스크립트 타입의 이슈가 있는데 (결제위젯 코드에서는 window.TossPayments가 정의되자 않음) 어떤방법이 좋을지 궁금합니다.