### PR TITLE
feat: src로 스크립트 찾아서 clear

### DIFF
--- a/packages/brandpay-sdk/src/clearBrandPay.ts
+++ b/packages/brandpay-sdk/src/clearBrandPay.ts
@@ -1,7 +1,7 @@
-import { SCRIPT_ID } from './constants';
+import { SCRIPT_URL } from './constants';
 
 export function clearBrandPay() {
-  const script = document.getElementById(SCRIPT_ID);
+  const script = document.querySelector(`script[src="${SCRIPT_URL}"]`);
 
   script?.parentElement?.removeChild(script);
   window.BrandPay = undefined;

--- a/packages/brandpay-sdk/src/constants.ts
+++ b/packages/brandpay-sdk/src/constants.ts
@@ -1,2 +1,1 @@
-export const SCRIPT_ID = `__tosspayments-brandpay-sdk__`;
 export const SCRIPT_URL = 'https://js.tosspayments.com/v1/brandpay';

--- a/packages/payment-sdk/src/clearTossPayments.ts
+++ b/packages/payment-sdk/src/clearTossPayments.ts
@@ -1,7 +1,7 @@
-import { SCRIPT_ID } from './constants';
+import { SCRIPT_URL } from './constants';
 
 export function clearTossPayments() {
-  const script = document.getElementById(SCRIPT_ID);
+  const script = document.querySelector(`script[src="${SCRIPT_URL}"]`);
 
   script?.parentElement?.removeChild(script);
   window.TossPayments = undefined;

--- a/packages/payment-sdk/src/constants.ts
+++ b/packages/payment-sdk/src/constants.ts
@@ -1,2 +1,1 @@
-export const SCRIPT_ID = `__tosspayments-sdk__`;
 export const SCRIPT_URL = 'https://js.tosspayments.com/v1';

--- a/packages/payment-widget-sdk/src/clearPaymentWidget.ts
+++ b/packages/payment-widget-sdk/src/clearPaymentWidget.ts
@@ -1,7 +1,7 @@
-import { SCRIPT_ID } from './constants';
+import { SCRIPT_URL } from './constants';
 
 export function clearPaymentWidget() {
-  const script = document.getElementById(SCRIPT_ID);
+  const script = document.querySelector(`script[src="${SCRIPT_URL}"]`);
 
   script?.parentElement?.removeChild(script);
   window.PaymentWidget = undefined;

--- a/packages/payment-widget-sdk/src/constants.ts
+++ b/packages/payment-widget-sdk/src/constants.ts
@@ -1,2 +1,1 @@
-export const SCRIPT_ID = `__tosspayments-payment-widget-sdk__`;
 export const SCRIPT_URL = 'https://js.tosspayments.com/v1/payment-widget';


### PR DESCRIPTION
- 현재 script에 id를 붙이지 않고 삽입하고 있는데 clear 함수에선 id로 스크립트를 찾습니다.
- src로 스크립트를 찾아서 clear 하도록 수정했습니다.
- constants id들은 삭제했습니다.

참고 [pr](https://github.com/tosspayments/browser-sdk/pull/46)