### PR TITLE
fix(brandpay-sdk): 하위호환성 깨지는 버전 무시하도록 SDK 버전 업

### DIFF
--- a/packages/brandpay-sdk/package.json
+++ b/packages/brandpay-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tosspayments/brandpay-sdk",
   "description": "TossPayments.js Brand Pay SDK",
-  "version": "1.1.8",
+  "version": "1.2.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
- 이미 존재하는 1.2.0 버전으로 인해 릴리즈가 실패하고 있습니다.
- `@tosspayments/brandpay__types@1.3.0` 에 맞춰서 `brandpay-sdk` 도 `1.3.0` 으로 배포될 수 있도록 버전을 올려줍니다