### PR TITLE
fix(brandpay-sdk): load option 파라미터 선언

### DIFF
--- a/packages/brandpay-sdk/src/loadBrandPay.ts
+++ b/packages/brandpay-sdk/src/loadBrandPay.ts
@@ -6,7 +6,7 @@ type BrandpayParams = Parameters<BrandpayConstructor>;
 
 interface LoadOptions {
   src?: string;
-  network?: Parameters<typeof loadScript>[2];
+  network?: 'high' | 'low' | 'auto';
 }
 
 export function loadBrandPay(


### PR DESCRIPTION
- sdk-loader 패키지는 brandpay-sdk 빌드 시 사라지는 의존성입니다
- 따라서 배포 버전에서는 `Parameters<typeof loadScript>[2]` 가 unknown 으로 평가됩니다.
- 올바른 타입 추론을 위해 별도로 타입을 선언합니다