### PR TITLE
fix(brandpay-sdk): 객체 형태로 넘기도록 변경

### DIFF
--- a/packages/brandpay-sdk/src/loadBrandPay.ts
+++ b/packages/brandpay-sdk/src/loadBrandPay.ts
@@ -23,7 +23,7 @@ export function loadBrandPay(
   }
 
   // regenerator-runtime 의존성을 없애기 위해 `async` 키워드를 사용하지 않는다
-  return loadScript<BrandpayConstructor>(src, 'BrandPay', network).then((BrandPay) => {
+  return loadScript<BrandpayConstructor>(src, 'BrandPay', { priority: network }).then((BrandPay) => {
     return BrandPay(clientKey, customerKey, options);
   });
 }

--- a/packages/brandpay-sdk/src/loadBrandPay.ts
+++ b/packages/brandpay-sdk/src/loadBrandPay.ts
@@ -23,7 +23,7 @@ export function loadBrandPay(
   }
 
   // regenerator-runtime 의존성을 없애기 위해 `async` 키워드를 사용하지 않는다
-  return loadScript<BrandpayConstructor>(src, 'BrandPay', { priority: network }).then((BrandPay) => {
-    return BrandPay(clientKey, customerKey, options);
+  return loadScript<BrandpayConstructor>(src, 'BrandPay', { priority: network }).then((Brandpay) => {
+    return Brandpay(clientKey, customerKey, options);
   });
 }


### PR DESCRIPTION
- loadScript의 세번째 파라미터가 객체형태인데 string 을 넘기고 있어서 수정합니다