### PR TITLE
refactor: 테스트 리팩토링

### DIFF
--- a/packages/sdk-loader/src/loadScript.test.ts
+++ b/packages/sdk-loader/src/loadScript.test.ts
@@ -22,9 +22,6 @@ describe('loadScript', () => {
 
       const { script } = mockScriptElement();
 
-      vi.spyOn(document, 'createElement')
-        .mockReturnValueOnce(script)
-
       // when
       const promise = loadScript('http://example.com/example.js', 'TossPayments');
       window.TossPayments = vi.fn(); // SDK는 주어진 namespace에 인스턴스를 생성함
@@ -37,9 +34,6 @@ describe('loadScript', () => {
       // given
       const { loadScript } = await import('./loadScript');
       const { script } = mockScriptElement();
-
-      vi.spyOn(document, 'createElement')
-        .mockReturnValueOnce(script)
 
       // when
       const promise = loadScript('http://example.com/example.js', 'TossPayments');
@@ -57,9 +51,6 @@ describe('loadScript', () => {
       // given
       const { loadScript } = await import('./loadScript');
       const { script } = mockScriptElement();
-
-      vi.spyOn(document, 'createElement')
-        .mockReturnValueOnce(script)
 
       // when
       const promise = loadScript('http://example.com/example.js', 'TossPayments');
@@ -94,9 +85,6 @@ describe('loadScript', () => {
       const { loadScript } = await import('./loadScript');
 
       const { script } = mockScriptElement();
-
-      vi.spyOn(document, 'createElement')
-        .mockReturnValueOnce(script)
 
       // when
       const promise1 = loadScript('http://example.com/script.js', 'TossPayments');
@@ -148,6 +136,9 @@ function mockScriptElement() {
   document.head.appendChild = vi.fn(); // NOTE: 테스트 환경에서 script inject 방지
 
   const script = document.createElement('script');
+
+  vi.spyOn(document, 'createElement')
+    .mockReturnValueOnce(script)
 
   return { script };
 }

--- a/packages/sdk-loader/src/loadScript.test.ts
+++ b/packages/sdk-loader/src/loadScript.test.ts
@@ -64,10 +64,6 @@ describe('loadScript', () => {
       const { loadScript } = await import('./loadScript');
       const { script } = mockScriptElement();
 
-      vi.spyOn(document, 'createElement')
-        .mockReturnValueOnce(script)
-
-
       // when
       const promise = loadScript('http://example.com/example.js', 'TossPayments', { priority: 'high' });
       window.TossPayments = vi.fn(); // SDK는 주어진 namespace에 인스턴스를 생성함
@@ -138,7 +134,7 @@ function mockScriptElement() {
   const script = document.createElement('script');
 
   vi.spyOn(document, 'createElement')
-    .mockReturnValueOnce(script)
+    .mockReturnValueOnce(script);
 
   return { script };
 }


### PR DESCRIPTION
## https://github.com/tosspayments/browser-sdk/pull/99 리뷰를 반영합니다

- addEventListener를 목킹하는 대신, dispatchEvent 메소드를 사용 [f557119](https://github.com/tosspayments/browser-sdk/commit/f557119293b56a204ad080c3b3fbcbc71d423082)
- document.createElement mocking은 유틸 내에서 공통으로 처리한다 [b357b7e](https://github.com/tosspayments/browser-sdk/commit/b357b7eb0bb0132d8c102262aaaaf032008ef139)