### PR TITLE
chore: ci workflow revert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        # 지정한 버전으로 배포하기 위해 임시로 CI package version up을 생략합니다
-        run: yarn lerna publish from-package --yes --concurrency=2
-        # TODO: v2 배포 후 아래 스크립트로 다시 변경
-        # run: |
-        #   yarn lerna version --conventional-commits --exclude-dependents --yes --git-remote origin
-        #   yarn lerna publish from-git --yes --concurrency=2
+        run: |
+          yarn lerna version --conventional-commits --exclude-dependents --yes --git-remote origin
+          yarn lerna publish from-git --yes --concurrency=2


### PR DESCRIPTION
https://github.com/tosspayments/browser-sdk/pull/101 의 배포가 완료되어 CI를 revert 합니다