### PR TITLE
chore: CI 배포 정상화를 위해 각 패키지 버전을 npm 배포 버전과 동기화합니다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,5 +48,5 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         # 지정한 버전으로 배포하기 위해 임시로 CI package version up을 생략합니다
         run: |
-          yarn lerna version --conventional-commits --exclude-dependents --yes --no-push
-          yarn lerna publish --dry-run from-git --yes --concurrency=2
+          yarn lerna version --conventional-commits --exclude-dependents --yes --git-remote origin
+          yarn lerna publish from-git --yes --concurrency=2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,5 +48,5 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         # 지정한 버전으로 배포하기 위해 임시로 CI package version up을 생략합니다
         run: |
-          yarn lerna version --conventional-commits --exclude-dependents --yes --git-remote origin
-          yarn lerna publish from-git --yes --concurrency=2
+          yarn lerna version --conventional-commits --exclude-dependents --yes --no-push
+          yarn lerna publish --dry-run from-git --yes --concurrency=2

--- a/packages/brandpay-sdk/CHANGELOG.md
+++ b/packages/brandpay-sdk/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.6.1](https://github.com/tosspayments/browser-sdk/compare/@tosspayments/brandpay-sdk@1.6.0...@tosspayments/brandpay-sdk@1.6.1) (2024-07-01)
-
-**Note:** Version bump only for package @tosspayments/brandpay-sdk
-
-
-
-
-
 ## [1.5.2](https://github.com/tosspayments/browser-sdk/compare/@tosspayments/brandpay-sdk@1.5.1...@tosspayments/brandpay-sdk@1.5.2) (2023-11-30)
 
 

--- a/packages/brandpay-sdk/package.json
+++ b/packages/brandpay-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tosspayments/brandpay-sdk",
   "description": "TossPayments.js Brand Pay SDK",
-  "version": "1.6.1",
+  "version": "1.6.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "types": "types/index.d.ts",

--- a/packages/payment-sdk/CHANGELOG.md
+++ b/packages/payment-sdk/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.8.1](https://github.com/tosspayments/browser-sdk/compare/@tosspayments/payment-sdk@1.8.0...@tosspayments/payment-sdk@1.8.1) (2024-07-01)
-
-**Note:** Version bump only for package @tosspayments/payment-sdk
-
-
-
-
-
 ## [1.7.1](https://github.com/tosspayments/browser-sdk/compare/@tosspayments/payment-sdk@1.7.0...@tosspayments/payment-sdk@1.7.1) (2024-03-26)
 
 

--- a/packages/payment-sdk/package.json
+++ b/packages/payment-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tosspayments/payment-sdk",
   "description": "TossPayments.js Payment SDK",
-  "version": "1.8.1",
+  "version": "1.8.0",
   "main": "dist/tosspayments.cjs.js",
   "module": "dist/tosspayments.esm.js",
   "types": "types/index.d.ts",

--- a/packages/payment-widget-sdk/CHANGELOG.md
+++ b/packages/payment-widget-sdk/CHANGELOG.md
@@ -1,16 +1,5 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## [0.11.1](https://github.com/tosspayments/browser-sdk/compare/@tosspayments/payment-widget-sdk@0.11.0...@tosspayments/payment-widget-sdk@0.11.1) (2024-07-01)
-
-**Note:** Version bump only for package @tosspayments/payment-widget-sdk
-
-
-
-
-
 ## [0.10.2](https://github.com/tosspayments/browser-sdk/compare/@tosspayments/payment-widget-sdk@0.10.1...@tosspayments/payment-widget-sdk@0.10.2) (2023-12-18)
 
 

--- a/packages/payment-widget-sdk/package.json
+++ b/packages/payment-widget-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tosspayments/payment-widget-sdk",
   "description": "TossPayments.js Payment Widget SDK.",
-  "version": "0.11.1",
+  "version": "0.11.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "types": "types/index.d.ts",

--- a/packages/sdk-loader/CHANGELOG.md
+++ b/packages/sdk-loader/CHANGELOG.md
@@ -1,16 +1,5 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## [2.0.1](https://github.com/tosspayments/browser-sdk/compare/@tosspayments/sdk-loader@2.0.0...@tosspayments/sdk-loader@2.0.1) (2024-07-01)
-
-**Note:** Version bump only for package @tosspayments/sdk-loader
-
-
-
-
-
 # [1.2.0](https://github.com/tosspayments/browser-sdk/compare/@tosspayments/sdk-loader@1.1.0...@tosspayments/sdk-loader@1.2.0) (2023-11-30)
 
 

--- a/packages/sdk-loader/package.json
+++ b/packages/sdk-loader/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tosspayments/sdk-loader",
   "description": "JavaScript SDK Loader by <script> tag injection",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "main": "src/index.ts",
   "publishConfig": {
     "access": "public",

--- a/packages/tosspayments-sdk/CHANGELOG.md
+++ b/packages/tosspayments-sdk/CHANGELOG.md
@@ -2,29 +2,3 @@
 
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-# [2.1.0](https://github.com/tosspayments/browser-sdk/compare/@tosspayments/tosspayments-sdk@2.0.2...@tosspayments/tosspayments-sdk@2.1.0) (2024-07-02)
-
-
-### Features
-
-* **tosspayment-sdk:** SDK 타입들을 번들링해 내보냅니다 ([#106](https://github.com/tosspayments/browser-sdk/issues/106)) ([f975cb8](https://github.com/tosspayments/browser-sdk/commit/f975cb889dcc2f9cdda31c78ac5eff2fa48b5279))
-
-
-
-
-
-## [2.0.2](https://github.com/tosspayments/browser-sdk/compare/@tosspayments/tosspayments-sdk@2.0.1...@tosspayments/tosspayments-sdk@2.0.2) (2024-07-01)
-
-
-### Bug Fixes
-
-* **@tosspayments-sdk:** 사용하는 측에서 타입 추론이 안 되는 이슈를 수정합니다 ([#105](https://github.com/tosspayments/browser-sdk/issues/105)) ([7625469](https://github.com/tosspayments/browser-sdk/commit/762546989c7f39b83d5344349f60dbb8be2339e5))
-
-
-
-
-
-## [2.0.1](https://github.com/tosspayments/browser-sdk/compare/@tosspayments/tosspayments-sdk@2.0.0...@tosspayments/tosspayments-sdk@2.0.1) (2024-07-01)
-
-**Note:** Version bump only for package @tosspayments/tosspayments-sdk

--- a/packages/tosspayments-sdk/package.json
+++ b/packages/tosspayments-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tosspayments/tosspayments-sdk",
   "description": "TossPayments.js Tosspayments SDK.",
-  "version": "2.1.0",
+  "version": "2.0.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
- npm 배포 버전에 맞게 CHAHNGELOG.md와 package 버전을 수정합니다
- 이 PR이 main에 머지되면서 CI가 돌면, npm에 publish 된 다음 버전으로 정상적으로 배포되기를 기대합니다