### PR TITLE
fix: clearTossPayments 가 사용된 src 를 정확히 제거하도록 변경 + sdk-loader 캐시 분리

### DIFF
--- a/.changeset/sdk-loader-src-namespace-cache-keying.md
+++ b/.changeset/sdk-loader-src-namespace-cache-keying.md
@@ -1,0 +1,7 @@
+---
+'@tosspayments/sdk-loader': minor
+---
+
+src·namespace 조합으로 로드 promise 를 캐싱하여 서로 다른 src 또는 namespace 가 같은 캐시를 공유하지 않도록 동작을 수정합니다. 동일 src·namespace 조합의 동시 호출은 기존처럼 dedupe 됩니다.
+
+`clearCache(src?, namespace?)` 함수를 새로 export 하여, 외부 SDK 가 reset/cleanup 시점에 stale promise 를 비울 수 있도록 합니다. 인자 없이 호출하면 전체 캐시, 둘 다 전달하면 해당 조합의 entry 만 제거합니다.

--- a/.changeset/tosspayments-sdk-clear-and-exports.md
+++ b/.changeset/tosspayments-sdk-clear-and-exports.md
@@ -1,0 +1,9 @@
+---
+'@tosspayments/tosspayments-sdk': patch
+---
+
+`clearTossPayments` 가 default URL 뿐 아니라 `loadTossPayments` 가 시도한 모든 src 의 스크립트를 정확히 제거하도록 수정합니다. 패키지 모듈 내부에 (src, namespace) 추적 state 를 두어, custom `src` 로 load 한 케이스에서도 자연스럽게 해당 스크립트와 sdk-loader 의 cache entry 가 함께 정리됩니다.
+
+SSR 환경에서 throw 하지 않도록 document/window 가드를 추가했으며, `window.TossPayments` 를 `delete` 로 정리하여 `in` 검사가 false 가 되도록 합니다.
+
+`package.json` 에 `exports` 필드를 추가하여 Node ESM / Vite / Next.js 등 modern bundler 의 conditional resolution(`types`/`import`/`require`) 을 지원합니다. `main`/`module`/`types` 필드는 구버전 호환을 위해 유지됩니다.

--- a/packages/sdk-loader/src/loadScript.test.ts
+++ b/packages/sdk-loader/src/loadScript.test.ts
@@ -126,6 +126,71 @@ describe('loadScript', () => {
     });
     test.todo('기존 src를 가진 script가 존재하면, 기존 script의 이벤트를 모두 제거하고 스크립트도 제거한 후 새로 만들어야 한다',);
   });
+
+  describe('src·namespace 조합 캐싱', () => {
+    test('다른 src 를 같은 namespace 로 호출하면 각각 별개의 promise 가 생성되고, 두 src 모두 그대로 inject 된다', async () => {
+      // given
+      const { loadScript } = await import('./loadScript');
+      const [scriptA, scriptB] = mockScriptElements(2);
+
+      // when
+      const promiseA = loadScript('http://example.com/a.js', 'TossPayments');
+      const promiseB = loadScript('http://example.com/b.js', 'TossPayments');
+
+      // then
+      expect(promiseA).not.toBe(promiseB);
+      expect(scriptA.src).toBe('http://example.com/a.js');
+      expect(scriptB.src).toBe('http://example.com/b.js');
+    });
+
+    test('같은 src 를 다른 namespace 로 호출하면 각각 별개의 promise 가 생성된다', async () => {
+      // given
+      const { loadScript } = await import('./loadScript');
+      mockScriptElements(2);
+
+      // when
+      const promiseA = loadScript('http://example.com/script.js', 'TossPayments');
+      const promiseB = loadScript('http://example.com/script.js', 'TossPaymentsBrandpay');
+
+      // then
+      expect(promiseA).not.toBe(promiseB);
+    });
+  });
+
+  describe('clearCache', () => {
+    test('인자 없이 호출하면 전체 캐시가 비워져 다음 loadScript 호출이 새 promise 를 생성한다', async () => {
+      // given
+      const { loadScript, clearCache } = await import('./loadScript');
+      mockScriptElements(2);
+
+      // when
+      const promise1 = loadScript('http://example.com/script.js', 'TossPayments');
+      clearCache();
+      const promise2 = loadScript('http://example.com/script.js', 'TossPayments');
+
+      // then
+      expect(promise1).not.toBe(promise2);
+    });
+
+    test('src·namespace 를 모두 전달하면 해당 entry 만 제거되고, 다른 entry 의 캐시는 유지된다', async () => {
+      // given
+      const { loadScript, clearCache } = await import('./loadScript');
+      mockScriptElements(3);
+
+      const promiseA1 = loadScript('http://example.com/a.js', 'TossPayments');
+      const promiseB1 = loadScript('http://example.com/b.js', 'TossPayments');
+
+      // when
+      clearCache('http://example.com/a.js', 'TossPayments');
+
+      const promiseA2 = loadScript('http://example.com/a.js', 'TossPayments');
+      const promiseB2 = loadScript('http://example.com/b.js', 'TossPayments');
+
+      // then
+      expect(promiseA1).not.toBe(promiseA2); // 비워진 entry 는 새 promise
+      expect(promiseB1).toBe(promiseB2); // 다른 entry 는 그대로
+    });
+  });
 });
 
 function mockScriptElement() {
@@ -137,4 +202,14 @@ function mockScriptElement() {
     .mockReturnValueOnce(script);
 
   return { script };
+}
+
+function mockScriptElements(count: number) {
+  document.head.appendChild = vi.fn(); // NOTE: 테스트 환경에서 script inject 방지
+
+  const scripts = Array.from({ length: count }, () => document.createElement('script'));
+  const spy = vi.spyOn(document, 'createElement');
+  scripts.forEach((s) => spy.mockReturnValueOnce(s));
+
+  return scripts;
 }

--- a/packages/sdk-loader/src/loadScript.ts
+++ b/packages/sdk-loader/src/loadScript.ts
@@ -1,13 +1,23 @@
-let cachedPromise: Promise<any> | null = null;
+// `${src}::${namespace}` 조합으로 캐싱하여 서로 다른 src/namespace 가 같은 캐시를 공유하지 않도록 합니다.
+// (이전 구현은 module-level 단일 promise라 첫 호출만 기억되어, 두 번째 호출이 다른 src 를 전달해도
+//  기존 promise 가 반환되던 문제가 있었습니다.)
+const cache = new Map<string, Promise<any>>();
+
+function cacheKey(src: string, namespace: string): string {
+  return `${src}::${namespace}`;
+}
 
 interface LoadOptions {
   priority?: 'high' | 'low' | 'auto';
 }
 
 export function loadScript<Namespace>(src: string, namespace: string, options: LoadOptions = {}): Promise<Namespace> {
-  // Return the cached Promise if it exists
-  if (cachedPromise != null) {
-    return cachedPromise;
+  const key = cacheKey(src, namespace);
+
+  // Return the cached Promise if it exists for this src/namespace combination
+  const hit = cache.get(key);
+  if (hit != null) {
+    return hit;
   }
 
   const promise = new Promise((resolve, reject) => {
@@ -59,13 +69,31 @@ export function loadScript<Namespace>(src: string, namespace: string, options: L
     }
   });
 
-  // Reset the cache if the Promise is rejected
-  cachedPromise = promise.catch(error => {
-    cachedPromise = null;
+  // Reset the cache entry if the Promise is rejected so the next call can retry
+  const cached: Promise<any> = promise.catch(error => {
+    cache.delete(key);
     return Promise.reject(error);
   });
 
-  return cachedPromise;
+  cache.set(key, cached);
+  return cached;
+}
+
+/**
+ * 캐싱된 loadScript Promise 를 비웁니다.
+ *
+ * - 인자 없이 호출하면 전체 캐시를 비웁니다.
+ * - src 와 namespace 를 모두 전달하면 해당 조합의 캐시만 제거합니다.
+ *
+ * 외부 SDK 의 reset/cleanup 로직에서 namespace 와 script 를 함께 정리할 때 호출하여
+ * 다음 loadScript 호출이 stale promise 를 반환하지 않도록 합니다.
+ */
+export function clearCache(src?: string, namespace?: string): void {
+  if (src != null && namespace != null) {
+    cache.delete(cacheKey(src, namespace));
+    return;
+  }
+  cache.clear();
 }
 
 function getNamespace<Namespace>(name: string) {

--- a/packages/tosspayments-sdk/package.json
+++ b/packages/tosspayments-sdk/package.json
@@ -5,6 +5,14 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "types": "types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "author": "Toss Payments",
   "repository": {
     "type": "git",

--- a/packages/tosspayments-sdk/src/clearTossPayments.test.ts
+++ b/packages/tosspayments-sdk/src/clearTossPayments.test.ts
@@ -65,4 +65,17 @@ describe(`clearTossPayments`, () => {
 
     expect(loadedRequests.size).toBe(0);
   });
+
+  test(`loadedRequests 가 비어있어도 외부에서 inject 한 default SCRIPT_URL 스크립트는 fallback 으로 제거된다`, () => {
+    // loadTossPayments 를 거치지 않고 HTML inline / SSR / 외부 코드가 직접 inject 한 케이스
+    const script = document.createElement(`script`);
+    script.src = SCRIPT_URL;
+    document.head.appendChild(script);
+
+    expect(loadedRequests.size).toBe(0); // precondition: 추적 state 비어있음
+
+    clearTossPayments();
+
+    expect(document.querySelector(`script[src="${SCRIPT_URL}"]`)).toBeNull();
+  });
 });

--- a/packages/tosspayments-sdk/src/clearTossPayments.test.ts
+++ b/packages/tosspayments-sdk/src/clearTossPayments.test.ts
@@ -1,23 +1,68 @@
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { clearTossPayments } from './clearTossPayments';
+import { loadedRequests } from './loadTossPayments';
 import { SCRIPT_URL } from './constants';
 
-const SCRIPT_ID = `__tosspayments-sdk__`;
+const NAMESPACE = `TossPayments`;
 
 describe(`clearTossPayments`, () => {
-  test(`토스페이먼츠 SDK 스크립트 태그를 제거하고, 전역에 존재하는 TossPayments 객체를 제거한다`, () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+    // @ts-ignore
+    delete window.TossPayments;
+    loadedRequests.clear();
+  });
+
+  test(`추적된 default URL 스크립트와 전역 TossPayments 객체를 제거한다`, () => {
     const script = document.createElement(`script`);
     script.src = SCRIPT_URL;
-    script.id = `__tosspayments-sdk__`;
     document.head.appendChild(script);
-
+    loadedRequests.set(SCRIPT_URL, { src: SCRIPT_URL, namespace: NAMESPACE });
     // @ts-ignore
     window.TossPayments = vi.fn();
 
     clearTossPayments();
 
-    expect(document.getElementById(SCRIPT_ID)).toBeNull();
+    expect(document.querySelector(`script[src="${SCRIPT_URL}"]`)).toBeNull();
     // @ts-ignore
     expect(window.TossPayments).toBeUndefined();
+  });
+
+  test(`추적된 custom src 스크립트도 제거한다`, () => {
+    const customSrc = `https://js.tosspayments.com/v1/brandpay`;
+    const script = document.createElement(`script`);
+    script.src = customSrc;
+    document.head.appendChild(script);
+    loadedRequests.set(customSrc, { src: customSrc, namespace: NAMESPACE });
+
+    clearTossPayments();
+
+    expect(document.querySelector(`script[src="${customSrc}"]`)).toBeNull();
+  });
+
+  test(`clear 후 'TossPayments' 키가 window 에서 완전히 제거되어 'in' 검사가 false 가 된다`, () => {
+    // @ts-ignore
+    window.TossPayments = vi.fn();
+
+    clearTossPayments();
+
+    expect(`TossPayments` in window).toBe(false);
+  });
+
+  test(`document 또는 window 가 undefined 인 SSR 환경에서 throw 하지 않는다`, () => {
+    vi.stubGlobal(`document`, undefined);
+    vi.stubGlobal(`window`, undefined);
+
+    expect(() => clearTossPayments()).not.toThrow();
+  });
+
+  test(`clear 후 loadedRequests state 가 비워진다`, () => {
+    loadedRequests.set(SCRIPT_URL, { src: SCRIPT_URL, namespace: NAMESPACE });
+
+    clearTossPayments();
+
+    expect(loadedRequests.size).toBe(0);
   });
 });

--- a/packages/tosspayments-sdk/src/clearTossPayments.ts
+++ b/packages/tosspayments-sdk/src/clearTossPayments.ts
@@ -1,4 +1,5 @@
 import { clearCache } from '@tosspayments/sdk-loader';
+import { SCRIPT_URL } from './constants';
 import { loadedRequests } from './loadTossPayments';
 
 export function clearTossPayments() {
@@ -6,12 +7,17 @@ export function clearTossPayments() {
     return;
   }
 
-  for (const { src, namespace } of loadedRequests.values()) {
+  loadedRequests.forEach(({ src, namespace }) => {
     const script = document.querySelector(`script[src="${src}"]`);
     script?.parentElement?.removeChild(script);
     clearCache(src, namespace);
-  }
+  });
   loadedRequests.clear();
+
+  // fallback: loadTossPayments 를 거치지 않고 HTML inline / SSR / 다른 코드 경로로 직접 inject 된
+  // default SCRIPT_URL 스크립트도 함께 정리합니다. (기존 동작 호환)
+  const defaultScript = document.querySelector(`script[src="${SCRIPT_URL}"]`);
+  defaultScript?.parentElement?.removeChild(defaultScript);
 
   // TODO: public interface에서 TossPayments의 global declaration 추가한 뒤 제거 예정입니다
   // @ts-ignore

--- a/packages/tosspayments-sdk/src/clearTossPayments.ts
+++ b/packages/tosspayments-sdk/src/clearTossPayments.ts
@@ -1,10 +1,19 @@
-import { SCRIPT_URL } from './constants';
+import { clearCache } from '@tosspayments/sdk-loader';
+import { loadedRequests } from './loadTossPayments';
 
 export function clearTossPayments() {
-  const script = document.querySelector(`script[src="${SCRIPT_URL}"]`);
+  if (typeof document === 'undefined' || typeof window === 'undefined') {
+    return;
+  }
 
-  script?.parentElement?.removeChild(script);
+  for (const { src, namespace } of loadedRequests.values()) {
+    const script = document.querySelector(`script[src="${src}"]`);
+    script?.parentElement?.removeChild(script);
+    clearCache(src, namespace);
+  }
+  loadedRequests.clear();
+
   // TODO: public interface에서 TossPayments의 global declaration 추가한 뒤 제거 예정입니다
   // @ts-ignore
-  window.TossPayments = undefined;
+  delete window.TossPayments;
 }

--- a/packages/tosspayments-sdk/src/loadTossPayments.ts
+++ b/packages/tosspayments-sdk/src/loadTossPayments.ts
@@ -4,6 +4,13 @@ import { TossPayments, TossPaymentsSDK } from '@tosspayments/standard-public-int
 
 type TosspaymentsParams = Parameters<TossPayments>;
 
+const NAMESPACE = 'TossPayments';
+
+// loadTossPayments 가 시도한 (src, namespace) 를 모듈 내부에 추적하여, clearTossPayments 가
+// 호출 시점에 정확히 동일한 스크립트와 sdk-loader 의 cache entry 를 정리할 수 있도록 합니다.
+// key 는 src 만 사용 (namespace 는 현재 고정), 같은 src 의 중복 load 는 자연스럽게 dedupe 됩니다.
+export const loadedRequests = new Map<string, { src: string; namespace: string }>();
+
 export function loadTossPayments(
   clientKey: TosspaymentsParams[0],
   loadOptions: { src?: string } = {}
@@ -15,8 +22,10 @@ export function loadTossPayments(
     return Promise.resolve({} as TossPaymentsSDK);
   }
 
+  loadedRequests.set(src, { src, namespace: NAMESPACE });
+
   // regenerator-runtime 의존성을 없애기 위해 `async` 키워드를 사용하지 않는다
-  return loadScript<TossPayments>(src, 'TossPayments').then((TossPayments) => {
+  return loadScript<TossPayments>(src, NAMESPACE).then((TossPayments) => {
     return TossPayments(clientKey);
   });
 }


### PR DESCRIPTION
`clearTossPayments` 가 custom src 로 로드된 스크립트를 제거하지 못하고, sdk-loader 의 캐시도 비우지 않던 문제를 수정합니다.

## @tosspayments/sdk-loader (minor)

- 모듈 단위로 단일 promise 만 캐싱하던 구조를 `Map<src::namespace, Promise>` 로 변경하여, 서로 다른 src 또는 namespace 의 호출이 같은 캐시를 공유하지 않도록 합니다. (다른 SDK 가 동시에 사용될 때 발생하던 캐시 공유 문제 해결)
- `clearCache(src?, namespace?)` 함수를 새로 export 합니다. 외부 SDK 의 cleanup 시점에 남아 있는 promise 를 비우기 위해 사용합니다.

## @tosspayments/tosspayments-sdk (patch)

- `loadTossPayments` 가 호출 시점에 사용한 (src, namespace) 를 모듈 내부에 저장하고, `clearTossPayments` 가 저장된 항목을 순회하여 해당 스크립트와 sdk-loader 의 캐시 항목을 함께 제거하도록 변경합니다.
- `loadTossPayments` 를 거치지 않고 HTML 에 직접 포함된 default `SCRIPT_URL` 스크립트도 함께 제거하도록 fallback 을 두었습니다. (기존 동작 호환)
- SSR(document/window 가 undefined) 환경에서 throw 하지 않도록 가드를 추가하고, `window.TossPayments` 를 `delete` 로 정리하여 `in` 연산자 검사가 false 가 되도록 합니다.
- `package.json` 에 `exports` 필드를 추가하여 modern bundler 의 conditional resolution 을 지원합니다. (`main` / `module` / `types` 필드는 구버전 호환을 위해 유지)

## 검증

- typecheck / test / build 모두 통과
- 단위 테스트: tosspayments-sdk 9 건, sdk-loader 11 건
- changeset 포함: sdk-loader **minor**, tosspayments-sdk **patch**