### PR TITLE
fix: changeset가 파싱 못 하는 sdk-loader workspace 의존성 형식 수정

### DIFF
--- a/packages/brandpay-sdk/package.json
+++ b/packages/brandpay-sdk/package.json
@@ -25,7 +25,7 @@
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-typescript": "^8.3.0",
-    "@tosspayments/sdk-loader": "workspace:packages/sdk-loader",
+    "@tosspayments/sdk-loader": "workspace:^",
     "happy-dom": "^14.12.3",
     "prettier": "^2.0.2",
     "rollup": "^2.60.0",

--- a/packages/payment-sdk/package.json
+++ b/packages/payment-sdk/package.json
@@ -25,7 +25,7 @@
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-typescript": "^8.3.0",
-    "@tosspayments/sdk-loader": "workspace:packages/sdk-loader",
+    "@tosspayments/sdk-loader": "workspace:^",
     "happy-dom": "^14.12.3",
     "prettier": "^2.0.2",
     "rollup": "^2.60.0",

--- a/packages/payment-widget-sdk/package.json
+++ b/packages/payment-widget-sdk/package.json
@@ -25,7 +25,7 @@
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-typescript": "^8.3.0",
-    "@tosspayments/sdk-loader": "workspace:packages/sdk-loader",
+    "@tosspayments/sdk-loader": "workspace:^",
     "happy-dom": "^14.12.3",
     "prettier": "^2.0.2",
     "rollup": "^2.60.0",

--- a/packages/tosspayments-sdk/package.json
+++ b/packages/tosspayments-sdk/package.json
@@ -33,7 +33,7 @@
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-typescript": "^8.3.0",
-    "@tosspayments/sdk-loader": "workspace:packages/sdk-loader",
+    "@tosspayments/sdk-loader": "workspace:^",
     "@tosspayments/standard-public-interfaces": "2.9.0",
     "happy-dom": "^14.12.3",
     "prettier": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2033,7 +2033,7 @@ __metadata:
     "@rollup/plugin-commonjs": ^21.0.1
     "@rollup/plugin-typescript": ^8.3.0
     "@tosspayments/brandpay__types": 1.16.1
-    "@tosspayments/sdk-loader": "workspace:packages/sdk-loader"
+    "@tosspayments/sdk-loader": "workspace:^"
     happy-dom: ^14.12.3
     prettier: ^2.0.2
     rollup: ^2.60.0
@@ -2085,7 +2085,7 @@ __metadata:
     "@rollup/plugin-commonjs": ^21.0.1
     "@rollup/plugin-typescript": ^8.3.0
     "@tosspayments/payment__types": 1.69.0
-    "@tosspayments/sdk-loader": "workspace:packages/sdk-loader"
+    "@tosspayments/sdk-loader": "workspace:^"
     happy-dom: ^14.12.3
     prettier: ^2.0.2
     rollup: ^2.60.0
@@ -2107,7 +2107,7 @@ __metadata:
     "@rollup/plugin-commonjs": ^21.0.1
     "@rollup/plugin-typescript": ^8.3.0
     "@tosspayments/payment-widget__types": 1.1.0
-    "@tosspayments/sdk-loader": "workspace:packages/sdk-loader"
+    "@tosspayments/sdk-loader": "workspace:^"
     happy-dom: ^14.12.3
     prettier: ^2.0.2
     rollup: ^2.60.0
@@ -2168,7 +2168,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tosspayments/sdk-loader@workspace:packages/sdk-loader":
+"@tosspayments/sdk-loader@workspace:^, @tosspayments/sdk-loader@workspace:packages/sdk-loader":
   version: 0.0.0-use.local
   resolution: "@tosspayments/sdk-loader@workspace:packages/sdk-loader"
   dependencies:
@@ -2196,7 +2196,7 @@ __metadata:
     "@rollup/plugin-babel": ^5.3.0
     "@rollup/plugin-commonjs": ^21.0.1
     "@rollup/plugin-typescript": ^8.3.0
-    "@tosspayments/sdk-loader": "workspace:packages/sdk-loader"
+    "@tosspayments/sdk-loader": "workspace:^"
     "@tosspayments/standard-public-interfaces": 2.9.0
     happy-dom: ^14.12.3
     prettier: ^2.0.2


### PR DESCRIPTION
## 문제
main push 시 도는 publish CI(`yarn changeset version`)가 실패.
https://github.com/tosspayments/browser-sdk/actions/runs/27395206423

```
🦋  error TypeError: Invalid comparator: packages/sdk-loader
    at versionPackage (@changesets/apply-release-plan/...)
```

## 원인
4개 SDK 패키지가 `@tosspayments/sdk-loader` 를 `"workspace:packages/sdk-loader"` 형식으로 참조.
yarn berry 는 이 상대경로 형식을 이해하지만, changeset 의 `apply-release-plan` 은
`workspace:` 뒤의 값을 semver comparator 로 파싱하므로 `packages/sdk-loader` 에서
`Invalid comparator` 로 터짐 (`^`/`~`/`*` 만 예외 처리됨).

changeset 은 **"이번 릴리스에서 버전이 바뀌는 패키지"를 참조하는 의존성의 범위만** 재계산함.
이전 릴리스들은 sdk-loader 를 버전업한 적이 없어 이 줄을 건드리지 않았으나,
\#147 이 sdk-loader 에 minor changeset 을 추가하면서 처음으로 범위 재계산이 트리거되어
잠재 버그가 드러난 것.

## 해결
`"workspace:packages/sdk-loader"` → `"workspace:^"` (4개 package.json + yarn.lock).
- 모두 `devDependencies` 라 publish 산출물에는 영향 없음
- 지금은 tosspayments-sdk 경로에서만 터지지만 나머지 3개도 동일 버그라 함께 수정

## 검증
- `yarn changeset version` 로컬 실행 → **exit 0 통과** (sdk-loader 2.0.2→2.1.0, tosspayments-sdk 2.7.0→2.7.1)
- 동일 버그 형식에서 sdk-loader changeset 유무로 재현 확인:
  - changeset **있음** → `Invalid comparator` 실패 (현 상태 재현)
  - changeset **제거** → 통과 (이전 릴리스 재현)