### PR TITLE
fix: 3개 SDK(brandpay/payment/payment-widget)의 clearXxx 가 사용된 src 를 정확히 제거하도록 변경

### DIFF
--- a/.changeset/brandpay-sdk-clear-and-exports.md
+++ b/.changeset/brandpay-sdk-clear-and-exports.md
@@ -1,0 +1,9 @@
+---
+'@tosspayments/brandpay-sdk': patch
+---
+
+`clearBrandPay` 가 default URL 뿐 아니라 `loadBrandPay` 가 시도한 모든 src 의 스크립트를 정확히 제거하도록 수정합니다. 패키지 모듈 내부에 (src, namespace) 추적 state 를 두어, custom `src` 로 load 한 케이스에서도 자연스럽게 해당 스크립트와 sdk-loader 의 cache entry 가 함께 정리됩니다.
+
+SSR 환경에서 throw 하지 않도록 document/window 가드를 추가했으며, `window.BrandPay` 를 `delete` 로 정리하여 `in` 검사가 false 가 되도록 합니다.
+
+`package.json` 에 `exports` 필드를 추가하여 Node ESM / Vite / Next.js 등 modern bundler 의 conditional resolution(`types`/`import`/`require`) 을 지원합니다. `main`/`module`/`types` 필드는 구버전 호환을 위해 유지됩니다.

--- a/.changeset/payment-sdk-clear-and-exports.md
+++ b/.changeset/payment-sdk-clear-and-exports.md
@@ -1,0 +1,9 @@
+---
+'@tosspayments/payment-sdk': patch
+---
+
+`clearTossPayments` 가 default URL 뿐 아니라 `loadTossPayments` 가 시도한 모든 src 의 스크립트를 정확히 제거하도록 수정합니다. 패키지 모듈 내부에 (src, namespace) 추적 state 를 두어, custom `src` 로 load 한 케이스에서도 자연스럽게 해당 스크립트와 sdk-loader 의 cache entry 가 함께 정리됩니다.
+
+SSR 환경에서 throw 하지 않도록 document/window 가드를 추가했으며, `window.TossPayments` 를 `delete` 로 정리하여 `in` 검사가 false 가 되도록 합니다.
+
+`package.json` 에 `exports` 필드를 추가하여 Node ESM / Vite / Next.js 등 modern bundler 의 conditional resolution(`types`/`import`/`require`) 을 지원합니다. `main`/`module`/`types` 필드는 구버전 호환을 위해 유지됩니다.

--- a/.changeset/payment-widget-sdk-clear-and-exports.md
+++ b/.changeset/payment-widget-sdk-clear-and-exports.md
@@ -1,0 +1,9 @@
+---
+'@tosspayments/payment-widget-sdk': patch
+---
+
+`clearPaymentWidget` 가 default URL 뿐 아니라 `loadPaymentWidget` 가 시도한 모든 src 의 스크립트를 정확히 제거하도록 수정합니다. 패키지 모듈 내부에 (src, namespace) 추적 state 를 두어, custom `src` 로 load 한 케이스에서도 자연스럽게 해당 스크립트와 sdk-loader 의 cache entry 가 함께 정리됩니다.
+
+SSR 환경에서 throw 하지 않도록 document/window 가드를 추가했으며, `window.PaymentWidget` 를 `delete` 로 정리하여 `in` 검사가 false 가 되도록 합니다.
+
+`package.json` 에 `exports` 필드를 추가하여 Node ESM / Vite / Next.js 등 modern bundler 의 conditional resolution(`types`/`import`/`require`) 을 지원합니다. `main`/`module`/`types` 필드는 구버전 호환을 위해 유지됩니다.

--- a/packages/brandpay-sdk/package.json
+++ b/packages/brandpay-sdk/package.json
@@ -5,6 +5,14 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "types": "types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "author": "Toss Payments",
   "repository": {
     "type": "git",

--- a/packages/brandpay-sdk/src/clearBrandPay.test.ts
+++ b/packages/brandpay-sdk/src/clearBrandPay.test.ts
@@ -1,22 +1,81 @@
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { clearBrandPay } from './clearBrandPay';
+import { loadedRequests } from './loadBrandPay';
 import { SCRIPT_URL } from './constants';
 
-const SCRIPT_ID = `__tosspayments-sdk__`;
+const NAMESPACE = `BrandPay`;
 
 describe(`clearBrandPay`, () => {
-  test(`토스페이먼츠 SDK 스크립트 태그를 제거하고, 전역에 존재하는 TossPayments 객체를 제거한다`, () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+    // @ts-ignore
+    delete window.BrandPay;
+    loadedRequests.clear();
+  });
+
+  test(`추적된 default URL 스크립트와 전역 BrandPay 객체를 제거한다`, () => {
+    const script = document.createElement(`script`);
+    script.src = SCRIPT_URL;
+    document.head.appendChild(script);
+    loadedRequests.set(SCRIPT_URL, { src: SCRIPT_URL, namespace: NAMESPACE });
     // @ts-ignore
     window.BrandPay = vi.fn();
 
+    clearBrandPay();
+
+    expect(document.querySelector(`script[src="${SCRIPT_URL}"]`)).toBeNull();
+    // @ts-ignore
+    expect(window.BrandPay).toBeUndefined();
+  });
+
+  test(`추적된 custom src 스크립트도 제거한다`, () => {
+    const customSrc = `https://js.tosspayments.com/v2/standard`;
     const script = document.createElement(`script`);
-    script.src = SCRIPT_URL;
-    script.id = `__tosspayments-sdk__`;
+    script.src = customSrc;
     document.head.appendChild(script);
+    loadedRequests.set(customSrc, { src: customSrc, namespace: NAMESPACE });
 
     clearBrandPay();
 
-    expect(document.getElementById(SCRIPT_ID)).toBeNull();
-    expect(window.BrandPay).toBeUndefined();
+    expect(document.querySelector(`script[src="${customSrc}"]`)).toBeNull();
+  });
+
+  test(`clear 후 'BrandPay' 키가 window 에서 완전히 제거되어 'in' 검사가 false 가 된다`, () => {
+    // @ts-ignore
+    window.BrandPay = vi.fn();
+
+    clearBrandPay();
+
+    expect(`BrandPay` in window).toBe(false);
+  });
+
+  test(`document 또는 window 가 undefined 인 SSR 환경에서 throw 하지 않는다`, () => {
+    vi.stubGlobal(`document`, undefined);
+    vi.stubGlobal(`window`, undefined);
+
+    expect(() => clearBrandPay()).not.toThrow();
+  });
+
+  test(`clear 후 loadedRequests state 가 비워진다`, () => {
+    loadedRequests.set(SCRIPT_URL, { src: SCRIPT_URL, namespace: NAMESPACE });
+
+    clearBrandPay();
+
+    expect(loadedRequests.size).toBe(0);
+  });
+
+  test(`loadedRequests 가 비어있어도 외부에서 inject 한 default SCRIPT_URL 스크립트는 fallback 으로 제거된다`, () => {
+    // loadBrandPay 를 거치지 않고 HTML inline / SSR / 외부 코드가 직접 inject 한 케이스
+    const script = document.createElement(`script`);
+    script.src = SCRIPT_URL;
+    document.head.appendChild(script);
+
+    expect(loadedRequests.size).toBe(0); // precondition: 추적 state 비어있음
+
+    clearBrandPay();
+
+    expect(document.querySelector(`script[src="${SCRIPT_URL}"]`)).toBeNull();
   });
 });

--- a/packages/brandpay-sdk/src/clearBrandPay.ts
+++ b/packages/brandpay-sdk/src/clearBrandPay.ts
@@ -1,8 +1,24 @@
+import { clearCache } from '@tosspayments/sdk-loader';
 import { SCRIPT_URL } from './constants';
+import { loadedRequests } from './loadBrandPay';
 
 export function clearBrandPay() {
-  const script = document.querySelector(`script[src="${SCRIPT_URL}"]`);
+  if (typeof document === 'undefined' || typeof window === 'undefined') {
+    return;
+  }
 
-  script?.parentElement?.removeChild(script);
-  window.BrandPay = undefined;
+  loadedRequests.forEach(({ src, namespace }) => {
+    const script = document.querySelector(`script[src="${src}"]`);
+    script?.parentElement?.removeChild(script);
+    clearCache(src, namespace);
+  });
+  loadedRequests.clear();
+
+  // fallback: loadBrandPay 를 거치지 않고 HTML inline / SSR / 다른 코드 경로로 직접 inject 된
+  // default SCRIPT_URL 스크립트도 함께 정리합니다. (기존 동작 호환)
+  const defaultScript = document.querySelector(`script[src="${SCRIPT_URL}"]`);
+  defaultScript?.parentElement?.removeChild(defaultScript);
+
+  // @ts-ignore
+  delete window.BrandPay;
 }

--- a/packages/brandpay-sdk/src/loadBrandPay.ts
+++ b/packages/brandpay-sdk/src/loadBrandPay.ts
@@ -9,6 +9,13 @@ interface LoadOptions {
   network?: 'high' | 'low' | 'auto';
 }
 
+const NAMESPACE = 'BrandPay';
+
+// loadBrandPay 가 시도한 (src, namespace) 를 모듈 내부에 추적하여, clearBrandPay 가
+// 호출 시점에 정확히 동일한 스크립트와 sdk-loader 의 cache entry 를 정리할 수 있도록 합니다.
+// key 는 src 만 사용 (namespace 는 현재 고정), 같은 src 의 중복 load 는 자연스럽게 dedupe 됩니다.
+export const loadedRequests = new Map<string, { src: string; namespace: string }>();
+
 export function loadBrandPay(
   clientKey: BrandpayParams[0],
   customerKey: BrandpayParams[1],
@@ -22,8 +29,10 @@ export function loadBrandPay(
     return Promise.resolve({} as BrandpayInstance);
   }
 
+  loadedRequests.set(src, { src, namespace: NAMESPACE });
+
   // regenerator-runtime 의존성을 없애기 위해 `async` 키워드를 사용하지 않는다
-  return loadScript<BrandpayConstructor>(src, 'BrandPay', { priority: network }).then((Brandpay) => {
+  return loadScript<BrandpayConstructor>(src, NAMESPACE, { priority: network }).then((Brandpay) => {
     return Brandpay(clientKey, customerKey, options);
   });
 }

--- a/packages/payment-sdk/package.json
+++ b/packages/payment-sdk/package.json
@@ -5,6 +5,14 @@
   "main": "dist/tosspayments.cjs.js",
   "module": "dist/tosspayments.esm.js",
   "types": "types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./dist/tosspayments.esm.js",
+      "require": "./dist/tosspayments.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "author": "Toss Payments",
   "repository": {
     "type": "git",

--- a/packages/payment-sdk/src/clearTossPayments.test.ts
+++ b/packages/payment-sdk/src/clearTossPayments.test.ts
@@ -1,22 +1,81 @@
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { clearTossPayments } from './clearTossPayments';
+import { loadedRequests } from './loadTossPayments';
 import { SCRIPT_URL } from './constants';
 
-const SCRIPT_ID = `__tosspayments-sdk__`;
+const NAMESPACE = `TossPayments`;
 
 describe(`clearTossPayments`, () => {
-  test(`토스페이먼츠 SDK 스크립트 태그를 제거하고, 전역에 존재하는 TossPayments 객체를 제거한다`, () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+    // @ts-ignore
+    delete window.TossPayments;
+    loadedRequests.clear();
+  });
+
+  test(`추적된 default URL 스크립트와 전역 TossPayments 객체를 제거한다`, () => {
+    const script = document.createElement(`script`);
+    script.src = SCRIPT_URL;
+    document.head.appendChild(script);
+    loadedRequests.set(SCRIPT_URL, { src: SCRIPT_URL, namespace: NAMESPACE });
     // @ts-ignore
     window.TossPayments = vi.fn();
 
+    clearTossPayments();
+
+    expect(document.querySelector(`script[src="${SCRIPT_URL}"]`)).toBeNull();
+    // @ts-ignore
+    expect(window.TossPayments).toBeUndefined();
+  });
+
+  test(`추적된 custom src 스크립트도 제거한다`, () => {
+    const customSrc = `https://js.tosspayments.com/v1/brandpay`;
     const script = document.createElement(`script`);
-    script.src = SCRIPT_URL;
-    script.id = `__tosspayments-sdk__`;
+    script.src = customSrc;
     document.head.appendChild(script);
+    loadedRequests.set(customSrc, { src: customSrc, namespace: NAMESPACE });
 
     clearTossPayments();
 
-    expect(document.getElementById(SCRIPT_ID)).toBeNull();
-    expect(window.TossPayments).toBeUndefined();
+    expect(document.querySelector(`script[src="${customSrc}"]`)).toBeNull();
+  });
+
+  test(`clear 후 'TossPayments' 키가 window 에서 완전히 제거되어 'in' 검사가 false 가 된다`, () => {
+    // @ts-ignore
+    window.TossPayments = vi.fn();
+
+    clearTossPayments();
+
+    expect(`TossPayments` in window).toBe(false);
+  });
+
+  test(`document 또는 window 가 undefined 인 SSR 환경에서 throw 하지 않는다`, () => {
+    vi.stubGlobal(`document`, undefined);
+    vi.stubGlobal(`window`, undefined);
+
+    expect(() => clearTossPayments()).not.toThrow();
+  });
+
+  test(`clear 후 loadedRequests state 가 비워진다`, () => {
+    loadedRequests.set(SCRIPT_URL, { src: SCRIPT_URL, namespace: NAMESPACE });
+
+    clearTossPayments();
+
+    expect(loadedRequests.size).toBe(0);
+  });
+
+  test(`loadedRequests 가 비어있어도 외부에서 inject 한 default SCRIPT_URL 스크립트는 fallback 으로 제거된다`, () => {
+    // loadTossPayments 를 거치지 않고 HTML inline / SSR / 외부 코드가 직접 inject 한 케이스
+    const script = document.createElement(`script`);
+    script.src = SCRIPT_URL;
+    document.head.appendChild(script);
+
+    expect(loadedRequests.size).toBe(0); // precondition: 추적 state 비어있음
+
+    clearTossPayments();
+
+    expect(document.querySelector(`script[src="${SCRIPT_URL}"]`)).toBeNull();
   });
 });

--- a/packages/payment-sdk/src/clearTossPayments.ts
+++ b/packages/payment-sdk/src/clearTossPayments.ts
@@ -1,8 +1,24 @@
+import { clearCache } from '@tosspayments/sdk-loader';
 import { SCRIPT_URL } from './constants';
+import { loadedRequests } from './loadTossPayments';
 
 export function clearTossPayments() {
-  const script = document.querySelector(`script[src="${SCRIPT_URL}"]`);
+  if (typeof document === 'undefined' || typeof window === 'undefined') {
+    return;
+  }
 
-  script?.parentElement?.removeChild(script);
-  window.TossPayments = undefined;
+  loadedRequests.forEach(({ src, namespace }) => {
+    const script = document.querySelector(`script[src="${src}"]`);
+    script?.parentElement?.removeChild(script);
+    clearCache(src, namespace);
+  });
+  loadedRequests.clear();
+
+  // fallback: loadTossPayments 를 거치지 않고 HTML inline / SSR / 다른 코드 경로로 직접 inject 된
+  // default SCRIPT_URL 스크립트도 함께 정리합니다. (기존 동작 호환)
+  const defaultScript = document.querySelector(`script[src="${SCRIPT_URL}"]`);
+  defaultScript?.parentElement?.removeChild(defaultScript);
+
+  // @ts-ignore
+  delete window.TossPayments;
 }

--- a/packages/payment-sdk/src/loadTossPayments.ts
+++ b/packages/payment-sdk/src/loadTossPayments.ts
@@ -2,6 +2,13 @@ import { TossPaymentsInstance, TossPaymentsConstructor } from '@tosspayments/pay
 import { loadScript } from '@tosspayments/sdk-loader';
 import { SCRIPT_URL } from './constants';
 
+const NAMESPACE = 'TossPayments';
+
+// loadTossPayments 가 시도한 (src, namespace) 를 모듈 내부에 추적하여, clearTossPayments 가
+// 호출 시점에 정확히 동일한 스크립트와 sdk-loader 의 cache entry 를 정리할 수 있도록 합니다.
+// key 는 src 만 사용 (namespace 는 현재 고정), 같은 src 의 중복 load 는 자연스럽게 dedupe 됩니다.
+export const loadedRequests = new Map<string, { src: string; namespace: string }>();
+
 export function loadTossPayments(
   clientKey: string,
   { src = SCRIPT_URL }: { src?: string } = {}
@@ -27,8 +34,10 @@ export function loadTossPayments(
     });
   }
 
+  loadedRequests.set(src, { src, namespace: NAMESPACE });
+
   // regenerator-runtime 의존성을 없애기 위해 `async` 키워드를 사용하지 않는다
-  return loadScript<TossPaymentsConstructor>(src, 'TossPayments').then((TossPayments) => {
+  return loadScript<TossPaymentsConstructor>(src, NAMESPACE).then((TossPayments) => {
     return TossPayments(clientKey);
   });
 }

--- a/packages/payment-widget-sdk/package.json
+++ b/packages/payment-widget-sdk/package.json
@@ -5,6 +5,14 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "types": "types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "author": "Toss Payments",
   "repository": {
     "type": "git",

--- a/packages/payment-widget-sdk/src/clearPaymentWidget.test.ts
+++ b/packages/payment-widget-sdk/src/clearPaymentWidget.test.ts
@@ -1,22 +1,81 @@
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { clearPaymentWidget } from './clearPaymentWidget';
+import { loadedRequests } from './loadPaymentWidget';
 import { SCRIPT_URL } from './constants';
 
-const SCRIPT_ID = `__tosspayments-sdk__`;
+const NAMESPACE = `PaymentWidget`;
 
 describe(`clearPaymentWidget`, () => {
-  test(`토스페이먼츠 SDK 스크립트 태그를 제거하고, 전역에 존재하는 TossPayments 객체를 제거한다`, () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+    // @ts-ignore
+    delete window.PaymentWidget;
+    loadedRequests.clear();
+  });
+
+  test(`추적된 default URL 스크립트와 전역 PaymentWidget 객체를 제거한다`, () => {
+    const script = document.createElement(`script`);
+    script.src = SCRIPT_URL;
+    document.head.appendChild(script);
+    loadedRequests.set(SCRIPT_URL, { src: SCRIPT_URL, namespace: NAMESPACE });
     // @ts-ignore
     window.PaymentWidget = vi.fn();
 
+    clearPaymentWidget();
+
+    expect(document.querySelector(`script[src="${SCRIPT_URL}"]`)).toBeNull();
+    // @ts-ignore
+    expect(window.PaymentWidget).toBeUndefined();
+  });
+
+  test(`추적된 custom src 스크립트도 제거한다`, () => {
+    const customSrc = `https://js.tosspayments.com/v1/brandpay`;
     const script = document.createElement(`script`);
-    script.src = SCRIPT_URL;
-    script.id = `__tosspayments-sdk__`;
+    script.src = customSrc;
     document.head.appendChild(script);
+    loadedRequests.set(customSrc, { src: customSrc, namespace: NAMESPACE });
 
     clearPaymentWidget();
 
-    expect(document.getElementById(SCRIPT_ID)).toBeNull();
-    expect(window.PaymentWidget).toBeUndefined();
+    expect(document.querySelector(`script[src="${customSrc}"]`)).toBeNull();
+  });
+
+  test(`clear 후 'PaymentWidget' 키가 window 에서 완전히 제거되어 'in' 검사가 false 가 된다`, () => {
+    // @ts-ignore
+    window.PaymentWidget = vi.fn();
+
+    clearPaymentWidget();
+
+    expect(`PaymentWidget` in window).toBe(false);
+  });
+
+  test(`document 또는 window 가 undefined 인 SSR 환경에서 throw 하지 않는다`, () => {
+    vi.stubGlobal(`document`, undefined);
+    vi.stubGlobal(`window`, undefined);
+
+    expect(() => clearPaymentWidget()).not.toThrow();
+  });
+
+  test(`clear 후 loadedRequests state 가 비워진다`, () => {
+    loadedRequests.set(SCRIPT_URL, { src: SCRIPT_URL, namespace: NAMESPACE });
+
+    clearPaymentWidget();
+
+    expect(loadedRequests.size).toBe(0);
+  });
+
+  test(`loadedRequests 가 비어있어도 외부에서 inject 한 default SCRIPT_URL 스크립트는 fallback 으로 제거된다`, () => {
+    // loadPaymentWidget 를 거치지 않고 HTML inline / SSR / 외부 코드가 직접 inject 한 케이스
+    const script = document.createElement(`script`);
+    script.src = SCRIPT_URL;
+    document.head.appendChild(script);
+
+    expect(loadedRequests.size).toBe(0); // precondition: 추적 state 비어있음
+
+    clearPaymentWidget();
+
+    expect(document.querySelector(`script[src="${SCRIPT_URL}"]`)).toBeNull();
   });
 });

--- a/packages/payment-widget-sdk/src/clearPaymentWidget.ts
+++ b/packages/payment-widget-sdk/src/clearPaymentWidget.ts
@@ -1,8 +1,24 @@
+import { clearCache } from '@tosspayments/sdk-loader';
 import { SCRIPT_URL } from './constants';
+import { loadedRequests } from './loadPaymentWidget';
 
 export function clearPaymentWidget() {
-  const script = document.querySelector(`script[src="${SCRIPT_URL}"]`);
+  if (typeof document === 'undefined' || typeof window === 'undefined') {
+    return;
+  }
 
-  script?.parentElement?.removeChild(script);
-  window.PaymentWidget = undefined;
+  loadedRequests.forEach(({ src, namespace }) => {
+    const script = document.querySelector(`script[src="${src}"]`);
+    script?.parentElement?.removeChild(script);
+    clearCache(src, namespace);
+  });
+  loadedRequests.clear();
+
+  // fallback: loadPaymentWidget 를 거치지 않고 HTML inline / SSR / 다른 코드 경로로 직접 inject 된
+  // default SCRIPT_URL 스크립트도 함께 정리합니다. (기존 동작 호환)
+  const defaultScript = document.querySelector(`script[src="${SCRIPT_URL}"]`);
+  defaultScript?.parentElement?.removeChild(defaultScript);
+
+  // @ts-ignore
+  delete window.PaymentWidget;
 }

--- a/packages/payment-widget-sdk/src/loadPaymentWidget.ts
+++ b/packages/payment-widget-sdk/src/loadPaymentWidget.ts
@@ -7,6 +7,13 @@ import { SCRIPT_URL } from './constants';
 
 type PaymentWidgetParams = Parameters<PaymentWidgetConstructor>;
 
+const NAMESPACE = 'PaymentWidget';
+
+// loadPaymentWidget 가 시도한 (src, namespace) 를 모듈 내부에 추적하여, clearPaymentWidget 가
+// 호출 시점에 정확히 동일한 스크립트와 sdk-loader 의 cache entry 를 정리할 수 있도록 합니다.
+// key 는 src 만 사용 (namespace 는 현재 고정), 같은 src 의 중복 load 는 자연스럽게 dedupe 됩니다.
+export const loadedRequests = new Map<string, { src: string; namespace: string }>();
+
 export function loadPaymentWidget(
   clientKey: PaymentWidgetParams[0],
   customerKey: PaymentWidgetParams[1],
@@ -20,8 +27,10 @@ export function loadPaymentWidget(
     return Promise.resolve({} as PaymentWidgetInstance);
   }
 
+  loadedRequests.set(src, { src, namespace: NAMESPACE });
+
   // regenerator-runtime 의존성을 없애기 위해 `async` 키워드를 사용하지 않는다
-  return loadScript<PaymentWidgetConstructor>(src, 'PaymentWidget').then((PaymentWidget) => {
+  return loadScript<PaymentWidgetConstructor>(src, NAMESPACE).then((PaymentWidget) => {
     return PaymentWidget(clientKey, customerKey, options);
   });
 }


### PR DESCRIPTION
#147 에서 `@tosspayments/tosspayments-sdk` + `@tosspayments/sdk-loader` 에 적용된 fix 를 나머지 3개 SDK 에도 동일하게 적용했어요.

## 변경 패키지

- `@tosspayments/brandpay-sdk` (patch)
- `@tosspayments/payment-sdk` (patch)
- `@tosspayments/payment-widget-sdk` (patch)

## 적용된 fix (요약)

- `loadXxx` 가 호출 시점에 사용한 `(src, namespace)` 를 모듈에 추적
- `clearXxx` 가 추적된 항목들의 스크립트 + `sdk-loader` 캐시를 함께 정리 (custom `src` 도 OK)
- `clearXxx` 에 SSR 가드 추가
- `window.X` 를 `delete` 로 정리 (`'X' in window` 가 false)
- `package.json` `exports` 필드 추가 (`main`/`module`/`types` 유지)

자세한 배경, 코드 예시, 호환성 노트는 #147 참고.

## 검증

- typecheck / vitest / rollup build 통과 (5 packages)
- 각 패키지 `clearXxx.test.ts` 에 PR #147 과 동일한 6가지 시나리오 추가