### PR TITLE
fix(ci): release checkout는 기본 GITHUB_TOKEN 사용 + fetch-depth/token 제거

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
       - name: setup pnpm
         uses: pnpm/action-setup@v6
       - name: setup node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOSSPAYMENTS_BOT_TOKEN }}
       - name: setup pnpm
         uses: pnpm/action-setup@v6
       - name: setup node.js


### PR DESCRIPTION
## 문제
PR #150 머지 후 Release 워크플로우가 checkout에서 실패:
```
fatal: could not read Username for 'https://github.com': terminal prompts disabled  (exit 128)
```
`actions/checkout`에 봇 PAT(`GH_TOSSPAYMENTS_BOT_TOKEN`)를 `token`으로 주입했는데, 그 PAT로 git fetch가 거부됨.

## 수정
- `checkout`은 레포 read만 필요 → 기본 `GITHUB_TOKEN` 사용 (커스텀 `token` 입력 제거)
- 봇 PAT는 PR 생성이 필요한 `changesets/action`에만 유지
- `fetch-depth: 0` 제거 — changesets는 changeset 파일 + npm 레지스트리 비교로 동작하므로 전체 git 히스토리 불필요 (기본 depth로 충분)

## 효과
- checkout 통과 → Release 워크플로우 정상화
- pending changeset이 없으면 `changeset publish`는 no-op이라 green
- 실제 Version PR 생성 시 `changesets/action`이 봇 PAT로 PR을 만들어 CI를 트리거 — 이때 PAT는 **Contents: RW + Pull requests: RW (+ org SSO 승인)** 가 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)
